### PR TITLE
Update origin repo for swift-syntax

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "d30dcd7bf5dc6ecbf7b1734f14aa672d744c0c9299c83ce368836fb4da641d5f",
   "pins" : [
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
         "version" : "510.0.2"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // Depend on the latest Swift 5.10 release of SwiftSyntax
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "510.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
`swift-syntax` repo has been moved to `swiftlang` GitHub org, this PR updates the `Package.swift` to the new repo URL.